### PR TITLE
Changed ubuntu version to 22

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,0 +1,57 @@
+name: Maven CI/CD
+
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  workflow_dispatch:
+
+jobs:
+
+  build_docker_image:
+    name: Publish to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+      - 
+        name: Checkout
+        uses: actions/checkout@v2
+      - 
+        name: Setup up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - 
+        name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - 
+        name: Populate Docker metadata
+        id: metadata
+        uses: docker/metadata-action@v3
+        with:
+          images: sismics/ubuntu
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ github.ref_type != 'tag' }}
+          labels: |
+            org.opencontainers.image.title = Ubuntu Base Image for Teedy
+            org.opencontainers.image.description = Teedy is an open source, lightweight document management system for individuals and businesses.
+            org.opencontainers.image.created = ${{ github.event_created_at }}
+            org.opencontainers.image.author = Sismics
+            org.opencontainers.image.url = https://teedy.io/
+            org.opencontainers.image.vendor = Sismics
+            org.opencontainers.image.license = GPLv2
+            org.opencontainers.image.version = ${{ github.event_head_commit.id }}
+      - 
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 MAINTAINER Benjamin Gamard <b.gamard@sismics.com>
 
 # Run Debian in non interactive mode


### PR DESCRIPTION
HI @jendib,

I have scanned the teedy image through AWS ECR.

It had more than 600 vulnerabilities with a lot of CRITICAL and HIGHs

Attaching the screenshot of the report

<img width="1051" alt="previous" src="https://github.com/sismics/docker-ubuntu/assets/7150428/41e517d0-ab1d-4cc1-b20b-1653d36457cf">

I have upgraded the ubuntu version in the base image. Now we only have 34 vulnerabilities


<img width="1034" alt="latest" src="https://github.com/sismics/docker-ubuntu/assets/7150428/d70c2867-43ba-47ff-b939-6c8f385d9892">

I will be working on the rest of the vulnerabilities too

